### PR TITLE
Fix pip error during remote import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [ # Base requirements
 
 [project.optional-dependencies]
 fftw = ["pyfftw"]
-mkl_fftw = ["mkl-fft"]
+mkl-fftw = ["mkl-fft"]
 jax = ["jax"]
 testing = ["nbodykit"]
 


### PR DESCRIPTION
I've fixed an error during optional dependencies import (See https://github.com/pypa/pip/issues/12431)