### PR TITLE
Fixed mkl_fft typo in dependency call

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [ # Base requirements
 
 [project.optional-dependencies]
 fftw = ["pyfftw"]
-mkl-fftw = ["mkl-fft"]
+mkl_fft = ["mkl-fft"]
 jax = ["jax"]
 testing = ["nbodykit"]
 


### PR DESCRIPTION
The issue in last PR was due to a typo instead of an hyphen change, my bad :(

It's fixed now and should work at import